### PR TITLE
Sort the version history

### DIFF
--- a/lib/paper_trail/version_queries.ex
+++ b/lib/paper_trail/version_queries.ex
@@ -86,7 +86,10 @@ defmodule PaperTrail.VersionQueries do
   end
 
   defp version_query(item_type, id) do
-    from(v in Version, where: v.item_type == ^item_type and v.item_id == ^id)
+    from(v in Version,
+      where: v.item_type == ^item_type and v.item_id == ^id,
+      order_by: [asc: v.inserted_at]
+    )
   end
 
   defp version_query(item_type, id, options) do


### PR DESCRIPTION
Problem:
`PaperTrail.get_versions/1`'s return is not always correctly sorted, so it needs to be sorted before being useful.

Solution:
Add an `ORDER_BY inserted_at ASC` to the query.